### PR TITLE
Get rid of 'finalizer references object to be finalized' warning

### DIFF
--- a/lib/magic.rb
+++ b/lib/magic.rb
@@ -67,7 +67,7 @@ class Magic
     end
 
     begin
-      ObjectSpace.define_finalizer(self){ close }
+      ObjectSpace.define_finalizer(self, self.class.finalize(@cookie)) if @cookie
     rescue
     end
   end
@@ -106,8 +106,9 @@ class Magic
     @path = path
   end
 
-  def close
-    magic_close(@cookie) if @cookie
-    @cookie = nil
+  def self.finalize(cookie)
+    proc {
+      magic_close(cookie)
+    }
   end
 end


### PR DESCRIPTION
In my application logs, I saw the message 'warning: finalizer references object to be finalized' a lot. [This blogpost](https://www.mikeperham.com/2010/02/24/the-trouble-with-ruby-finalizers/) explains what causes this warning and how to solve it. This PR contains the changes to make the warning go away.